### PR TITLE
Tweaks as result of OSX Testing

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/importWizards/ImportWizardPage.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/importWizards/ImportWizardPage.java
@@ -102,9 +102,9 @@ public class ImportWizardPage extends WizardResourceImportPage {
 		fIPText = new StringFieldEditor("IPSelect", "Server IP:  ", fileSelectionArea);
 		fIPText.setStringValue("10.173.84.202");
 		fUserText = new StringFieldEditor("User", "User:  ", fileSelectionArea);
-		fUserText.setStringValue("gosmith");
+		fUserText.setStringValue("");
 		fPasswordText = new PasswordFieldEditor("Password", "Password:  ", fileSelectionArea);
-		fPasswordText.setStringValue("password");
+		fPasswordText.setStringValue("");
 	}
 
 	@Override

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/AllItemView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/AllItemView.java
@@ -93,7 +93,6 @@ class ClusterView extends PlatformBaseView {
 		super(treeViewer, parent, platform);
 		this.cluster = cluster;
 		clusterName = cluster.getName();
-		refreshChildren();
 	}
 
 	@Override
@@ -155,7 +154,6 @@ class DropZoneView extends PlatformBaseView {
 	DropZoneView(TreeItemOwner treeViewer, PlatformBaseView parent, Platform platform, DropZone dropZone) {
 		super(treeViewer, parent, platform);
 		this.dropZone = dropZone;
-		refreshChildren();
 	}
 
 	@Override
@@ -389,7 +387,6 @@ class LogicalFileContentsView extends PlatformBaseView {
 	LogicalFileContentsView(TreeItemOwner treeViewer, PlatformBaseView parent, Platform platform, LogicalFile file) {
 		super(treeViewer, parent, platform);
 		this.file = file; 
-		refreshChildren();
 	}
 
 	@Override
@@ -414,7 +411,6 @@ class LandingZoneFileView extends PlatformBaseView {
 	LandingZoneFileView(TreeItemOwner treeViewer, PlatformBaseView parent, Platform platform, String path) {
 		super(treeViewer, parent, platform);
 		this.path = path; 
-		refreshChildren();
 	}
 
 	@Override
@@ -436,7 +432,6 @@ class ResultViewView extends PlatformBaseView {
 		super(treeViewer, parent, platform);
 		this.result = result; 
 		this.viewName = viewName;
-		refreshChildren();
 	}
 
 	@Override
@@ -500,7 +495,6 @@ class MessageItemView extends ItemView {
 	MessageItemView(TreeItemOwner treeViewer, ItemView parent, String message) {
 		super(treeViewer, parent);
 		this.message = message;
-		refreshChildren();
 	}
 
 	@Override

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/FileSprayWorkunitFolderView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/FileSprayWorkunitFolderView.java
@@ -83,8 +83,10 @@ public class FileSprayWorkunitFolderView extends FolderItemView implements Obser
 		for (DataSingleton ds : delta.getAdded()) {
 			if (ds instanceof FileSprayWorkunit) {
 				FileSprayWorkunit wu = (FileSprayWorkunit)ds;
-				children.add(new FileSprayWorkunitView(treeViewer, this, wu));						
-				changed = true;
+				if (platform.equals(wu.getPlatform())  && (clusterName.isEmpty() || clusterName.equals(wu.getClusterName()))) {
+					children.add(new FileSprayWorkunitView(treeViewer, this, wu));						
+					changed = true;
+				}
 			}
 		}
 

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/FileSprayWorkunitView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/FileSprayWorkunitView.java
@@ -33,7 +33,6 @@ public class FileSprayWorkunitView extends PlatformBaseView implements Observer 
 		super(treeViewer, parent, wu.getPlatform());
 		workunit = wu;
 		workunit.addObserver(this);
-		refreshChildren();
 	}
 
 	public FileSprayWorkunit getFileSprayWorkunit() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/GraphView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/GraphView.java
@@ -17,7 +17,6 @@ public class GraphView extends PlatformBaseView implements Observer {
 		super(treeViewer, parent, platform);
 		this.graph = graph; 
 		this.graph.addObserver(this);
-		refreshChildren();
 	}
 
 	public Graph getGraph() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/PlatformView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/PlatformView.java
@@ -23,7 +23,6 @@ public class PlatformView extends PlatformBaseView {
 
 	PlatformView(TreeItemOwner treeViewer, PlatformBaseView parent, Platform platform) {
 		super(treeViewer, parent, platform);
-		refreshChildren();
 	}
 
 	public Platform getPlatform() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/ResultView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/ResultView.java
@@ -19,7 +19,6 @@ public class ResultView extends PlatformBaseView implements Observer {
 		super(treeViewer, parent, platform);
 		this.result = result; 
 		this.result.addObserver(this);
-		refreshChildren();
 	}
 
 	@Override

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/TextItemView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/TextItemView.java
@@ -23,7 +23,6 @@ public class TextItemView extends PlatformBaseView {
 	TextItemView(TreeItemOwner treeViewer, PlatformBaseView parent, Workunit workunit) {
 		super(treeViewer, parent, workunit.getPlatform());
 		this.workunit = workunit; 
-		refreshChildren();
 	}
 
 	public Workunit getWorkunit() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/WorkunitView.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/WorkunitView.java
@@ -31,7 +31,6 @@ public class WorkunitView extends PlatformBaseView implements Observer {
 		super(treeViewer, parent, wu.getPlatform());
 		workunit = wu;
 		workunit.addObserver(this);
-		refreshChildren();
 	}
 
 	public Workunit getWorkunit() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/wizards/ImportWizardPage.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/wizards/ImportWizardPage.java
@@ -85,9 +85,9 @@ public class ImportWizardPage extends WizardResourceImportPage {
 		fIPText = new StringFieldEditor("IPSelect", "Server IP:  ", fileSelectionArea);
 		fIPText.setStringValue("10.173.84.202");
 		fUserText = new StringFieldEditor("User", "User:  ", fileSelectionArea);
-		fUserText.setStringValue("gosmith");
+		fUserText.setStringValue("");
 		fPasswordText = new PasswordFieldEditor("Password", "Password:  ", fileSelectionArea);
-		fPasswordText.setStringValue("password");
+		fPasswordText.setStringValue("");
 	}
 
 	@Override

--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/CmdArgs.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/CmdArgs.java
@@ -32,7 +32,10 @@ public class CmdArgs {
 		QUOTE = OS.isWindowsPlatform() ? "\"" : "";
 
 		this.cmd = cmd;
-		String allArgs = commonArgs + " " + baseArgs;
+		String allArgs = commonArgs;
+		if (!allArgs.isEmpty())
+			allArgs += " "; 
+		allArgs += baseArgs;
 		this.baseArgs = Arrays.asList(allArgs.split(" "));
 		args = new TreeMap<String, Set<String>>();
 	}

--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/FileSprayWorkunit.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/FileSprayWorkunit.java
@@ -236,4 +236,11 @@ public class FileSprayWorkunit extends DataSingleton {
 		result = HashCodeUtil.hash(result, info.getID());
 		return result;
 	}
+
+	public Object getClusterName() {
+		if (info.getClusterName() == null) {
+			fullRefresh();
+		}
+		return info.getClusterName();
+	}
 }

--- a/org.hpccsystems.updatesite/site.xml
+++ b/org.hpccsystems.updatesite/site.xml
@@ -3,7 +3,7 @@
    <description name="HPCC Sytems Update Site" url="http://cdn.hpccsystems.com/install/eclipse/develop/">
       Update site for Eclipse ECL Plugin.
    </description>
-   <feature url="features/ECL_Language_1.0.0.201204061101.jar" id="ECL_Language" version="1.0.0.201204061101">
+   <feature url="features/ECL_Language_1.0.0.201207121347.jar" id="ECL_Language" version="1.0.0.201207121347">
       <category name="hpcc_systems"/>
    </feature>
    <category-def name="hpcc_systems" label="HPCC Systems">


### PR DESCRIPTION
Remove double call to RefreshChildren.
Change to faster call to get list of target clusters.
Fix number of args sent to command line (caused issue on OSX)

Signed-off-by: Gordon Smith gordonjsmith@gmail.com
