### PR TITLE
gh-58 ECL Text Colours and '<', '>'

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/text/CPPRule.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/text/CPPRule.java
@@ -14,15 +14,16 @@ import org.eclipse.jface.text.rules.ICharacterScanner;
 import org.eclipse.jface.text.rules.IToken;
 import org.eclipse.jface.text.rules.MultiLineRule;
 
-public class ECLRule extends MultiLineRule {
+public class CPPRule extends MultiLineRule {
 
-	public ECLRule(IToken token) {
-		super("<", ">", token);
+	public CPPRule(IToken token) {
+		super("beginc++", "endc++", token);
 	}
 
 	@Override
 	protected boolean sequenceDetected(ICharacterScanner scanner, char[] sequence, boolean eofAllowed) {
 		int c = scanner.read();
+		/*
 		if (sequence[0] == '<') {
 			if (c == '?') {
 				// processing instruction - abort
@@ -37,6 +38,7 @@ public class ECLRule extends MultiLineRule {
 		} else if (sequence[0] == '>') {
 			scanner.unread();
 		}
+		*/
 		return super.sequenceDetected(scanner, sequence, eofAllowed);
 	}
 }

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/text/ECLPartitionScanner.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/text/ECLPartitionScanner.java
@@ -16,19 +16,24 @@ import org.eclipse.jface.text.rules.EndOfLineRule;
 import org.eclipse.jface.text.rules.IPredicateRule;
 import org.eclipse.jface.text.rules.IRule;
 import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.IWhitespaceDetector;
 import org.eclipse.jface.text.rules.MultiLineRule;
+import org.eclipse.jface.text.rules.PatternRule;
 import org.eclipse.jface.text.rules.RuleBasedPartitionScanner;
 import org.eclipse.jface.text.rules.Token;
+import org.eclipse.jface.text.rules.WhitespaceRule;
 
 public class ECLPartitionScanner extends RuleBasedPartitionScanner {
 	public final static String ECL_COMMENT = "__ecl_comment";
 	public final static String ECL_JAVADOC = "__ecl_javadoc";
+	public final static String ECL_CPP = "__ecl_cpp";
 	public final static String ECL_BODY = "__ecl_body";
 
 	public ECLPartitionScanner() {
 
 		IToken eclComment = new Token(ECL_COMMENT);
 		IToken eclJavaDoc = new Token(ECL_JAVADOC);
+		IToken eclCpp = new Token(ECL_CPP);
 		IToken eclBody = new Token(ECL_BODY);
 
 		ArrayList<IRule> rules= new ArrayList<IRule>();
@@ -40,8 +45,8 @@ public class ECLPartitionScanner extends RuleBasedPartitionScanner {
 		rules.add(new EndOfLineRule("//", eclComment));
 		rules.add(new MultiLineRule("/*", "*/", eclComment));
 
-		//  Actual ECL
-		rules.add(new ECLRule(eclBody));
+		//  CPP
+		rules.add(new CPPRule(eclCpp));
 
 		IPredicateRule[] result= new IPredicateRule[rules.size()];
 		rules.toArray(result);


### PR DESCRIPTION
Removed old invalid code and replaced with possible multi language coloring hook.

Fixes gh-58

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
