### PR TITLE
gh-60 Launch Configuration Window keeps resizing

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/launchers/ECLLaunchServerTab.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/launchers/ECLLaunchServerTab.java
@@ -121,7 +121,7 @@ public class ECLLaunchServerTab extends ECLLaunchConfigurationTab {
 
 		browser = new Browser(group, SWT.BORDER);
 		browser.setUrl("about:blank");
-		GridData gd = new GridData(GridData.FILL_BOTH);
+		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true);
 		gd.horizontalSpan = 3;
 		browser.setLayoutData(gd);
 		browser.addAuthenticationListener(new AuthenticationListener() {


### PR DESCRIPTION
Changed how the layout grid is initialized.

Fixes gh-60

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
