### PR TITLE
gh-68 Add "$" support to ECL Meta Information

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLMetaTree.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLMetaTree.java
@@ -225,6 +225,26 @@ public class ECLMetaTree implements Serializable {
 			return null;
 		}
 
+		public ECLMetaNode getECLFolderNode() {
+			if (data instanceof ECLFolder) {
+				return this;
+			}
+			if (parent != null) {
+				return parent.getECLFolderNode();
+			}
+			return null;
+		}
+
+		public ECLMetaNode getECLSourceNode() {
+			if (data instanceof ECLSource) {
+				return this;
+			}
+			if (parent != null) {
+				return parent.getECLSourceNode();
+			}
+			return null;
+		}
+
 		public String getName() {
 			return name;
 		}
@@ -264,6 +284,15 @@ public class ECLMetaTree implements Serializable {
 		}
 
 		public ECLMetaNode findDefinition(String text, boolean downOnly) {
+			if (text.startsWith("$")) {
+				ECLMetaNode eclFolderNode = this.getECLFolderNode();
+				if (eclFolderNode != null) {
+					text = eclFolderNode.getName() + text.substring(1);
+				}
+			}
+			if (text.startsWith("$.")) {
+				text = text.substring(2);				
+			}
 			text = text.toLowerCase();
 			if (getName().equalsIgnoreCase(text)) {
 				return this;
@@ -291,12 +320,10 @@ public class ECLMetaTree implements Serializable {
 				return null;
 			}
 
-			// Find stops walking up up at the source level ---
-			if (getData() instanceof ECLSource) {
-				return null;
+			if (parent != null) {
+				return parent.findDefinition(text, false);
 			}
-
-			return parent.findDefinition(text, false);
+			return null;
 		}
 
 		public Collection<ECLMetaNode> getChildren() {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLCompletionProcessor.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLCompletionProcessor.java
@@ -67,8 +67,6 @@ public class ECLCompletionProcessor implements IContentAssistProcessor {
 			IFile file = ((ECLDocument)doc).getFile();
 			ECLMetaNode source = ECLGlobalMeta.get().getSource(file);
 			if (source != null) {
-				ECLMetaNode context = source.getContext(offset);
-
 				String knownText = getAutoCKnownString(doc, offset);
 				String remainingText = getAutoCRemainingString(doc, offset);
 				int replacementPos = ECLEditor.getFirstCharOffset(doc, offset, false);
@@ -83,13 +81,16 @@ public class ECLCompletionProcessor implements IContentAssistProcessor {
 					}
 
 				} else {
-					ECLMetaNode def = context.findDefinition(knownText, false);
-					if (def != null) {
-						for (ECLMetaNode child_def : def.getChildren()) {
-							if (child_def.getName().toLowerCase().startsWith(remainingText.toLowerCase())) {
-								result.add(new CompletionProposal(child_def.getName(), replacementPos, endReplacementPos - replacementPos, child_def.getName().length()));
+					ECLMetaNode context = source.getContext(offset);
+					if (context != null) {
+						ECLMetaNode def = context.findDefinition(knownText, false);
+						if (def != null) {
+							for (ECLMetaNode child_def : def.getChildren()) {
+								if (child_def.getName().toLowerCase().startsWith(remainingText.toLowerCase())) {
+									result.add(new CompletionProposal(child_def.getName(), replacementPos, endReplacementPos - replacementPos, child_def.getName().length()));
+								}
 							}
-						}			
+						}
 					}
 				}
 			}


### PR DESCRIPTION
"$" should be substituted for current folder in meta tree
(auto completion and F3 open declaration support).

Fixes gh-68

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
