### PR TITLE
EPE-2 Overview Window "Over" Refreshing

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLGlobalMeta.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLGlobalMeta.java
@@ -81,11 +81,8 @@ public class ECLGlobalMeta {
 		@Override
 		public void endElement(String uri, String localName, String qName) throws SAXException {
 			Element e = elementStack.peek();
-			if (e.tag.equals("Source")) {
-				metaStack.pop();
-			} else if (e.tag.equals("Definition")) {
-				metaStack.pop();
-			} else if (e.tag.equals("Field")) {
+			if (e.tag.equals("Source") || e.tag.equals("Definition") || e.tag.equals("Field")) {
+				metaStack.peek().notifyObservers("endElement");
 				metaStack.pop();
 			} else if (e.tag.equals("Import")) {
 			}

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLMetaTree.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/meta/ECLMetaTree.java
@@ -184,10 +184,10 @@ public class ECLMetaTree implements Serializable {
 				children.put(name, new ECLMetaNode(this, name, data));
 			}
 			setChanged();
-			notifyObservers();
-			if (parent != null) {
-				parent.setChanged();
-				parent.notifyObservers();
+			ECLMetaNode parentNode = parent;
+			while (parentNode != null) {
+				parentNode.setChanged();
+				parentNode = parentNode.parent;
 			}
 			return children.get(name);
 		}

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/MetaSourceTreeItemContentProvider.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/MetaSourceTreeItemContentProvider.java
@@ -96,12 +96,14 @@ class MetaSourceTreeItemContentProvider implements ITreeContentProvider, Observe
 			}
 		}
 
-		Display.getDefault().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				viewer.refresh(source);
-			}
-		});
+		if (arg0.equals(source)) {
+			Display.getDefault().syncExec(new Runnable() {
+				@Override
+				public void run() {
+					viewer.refresh(source);
+				}
+			});
+		}
 	}
 
 }


### PR DESCRIPTION
The overview window was excessively refreshing during a syntax check/compile.

Fixes EPE-2

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
