### PR TITLE
EPE-34 ECL Watch Perspective Corruption

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/Workbench.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/Workbench.java
@@ -1,0 +1,45 @@
+package org.hpccsystems.eclide;
+
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IPerspectiveDescriptor;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+
+public class Workbench {
+	
+	static IWorkbench getWorkbench() {
+		return PlatformUI.getWorkbench();
+	}
+	
+	static public IWorkbenchWindow getActiveWorkbenchWindow() {
+		return getWorkbench().getActiveWorkbenchWindow();
+	}
+	
+	static public IWorkbenchPage getActivePage() {
+		return getActiveWorkbenchWindow().getActivePage();
+	}
+
+	static public IPerspectiveDescriptor getActivePerspective() {
+		return getActivePage().getPerspective();
+	}
+
+	public static IEditorPart getActiveEditor() {
+		return getActivePage().getActiveEditor();
+	}
+
+	public static Display getDisplay() {
+		return getWorkbench().getDisplay();
+	}
+
+	public static Shell getShell() {
+		return getActiveWorkbenchWindow().getShell();
+	}
+
+	public static IWorkbenchWindow[] getWorkbenchWindows() {
+		return getWorkbench().getWorkbenchWindows();
+	}
+}

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/handlers/OpenDeclarationHandler.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/handlers/OpenDeclarationHandler.java
@@ -18,9 +18,9 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
 import org.eclipse.ui.ide.IDE;
+import org.hpccsystems.eclide.Workbench;
 import org.hpccsystems.eclide.builder.meta.ECLMetaTree.ECLMetaNode;
 import org.hpccsystems.eclide.editors.ECLEditor;
 import org.hpccsystems.eclide.editors.ECLWindow;
@@ -58,7 +58,7 @@ public class OpenDeclarationHandler extends AbstractHandler {
 					if (filePath != null) {
 						IFile fileToBeOpened = Eclipse.findFile(filePath, editor.getProject());
 						try {
-							IEditorPart ep = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), fileToBeOpened, true);
+							IEditorPart ep = IDE.openEditor(Workbench.getActivePage(), fileToBeOpened, true);
 							((ECLWindow) ep).gotoLine(def.getLine());
 						} catch (PartInitException e) {
 							e.printStackTrace();

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/PlatformViewer.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/ui/viewer/platform/PlatformViewer.java
@@ -47,10 +47,12 @@ import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IPersistableElement;
 import org.eclipse.ui.IStorageEditorInput;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.ViewPart;
+import org.hpccsystems.eclide.Workbench;
 import org.hpccsystems.eclide.editors.ECLWindow;
+import org.hpccsystems.eclide.perspectives.ECLPerspective;
+import org.hpccsystems.eclide.perspectives.ECLWatch;
 import org.hpccsystems.eclide.ui.viewer.HtmlViewer;
 import org.hpccsystems.eclide.ui.viewer.platform.PlatformActions.IPlatformUI;
 import org.hpccsystems.internal.Eclipse;
@@ -289,32 +291,33 @@ public class PlatformViewer extends ViewPart {
 						if (next instanceof ItemView) {
 							ItemView item  = (ItemView)next;
 
-							//  Editor View  ---
-							WorkunitView wuView = item.getWorkunitAncestor();
-							if (wuView != null) {
-								//WorkunitEditorInput workunitEditorInput = getWorkunitEditorInput(wuView);
-								WorkunitInput workunitInput = new WorkunitInput(wuView.getWorkunit());
-								IEditorPart ep = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
-								if (ep != null) {
-									IEditorInput input = ep.getEditorInput();
-									if (input.equals(workunitInput)) {
-										PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().activate(ep);
-										((ECLWindow) ep).showItemView((ItemView)next, false);
-									} else if (input instanceof IFileEditorInput) {
-										IFileEditorInput fileInput = (IFileEditorInput)input; 
-										IFile file = fileInput.getFile();
-										String editorPath = file.getFullPath().toPortableString();
-										String workunitPath = workunitInput.getOrigonalFilePath();
-										if (editorPath.compareTo(workunitPath) == 0) {
-											PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().activate(ep);
+							if (Workbench.getActivePerspective().getId().equals(ECLPerspective.PERSPECTIVE_ID)) {
+								WorkunitView wuView = item.getWorkunitAncestor();
+								if (wuView != null) {
+									//WorkunitEditorInput workunitEditorInput = getWorkunitEditorInput(wuView);
+									WorkunitInput workunitInput = new WorkunitInput(wuView.getWorkunit());
+									IEditorPart ep = Workbench.getActiveEditor();
+									if (ep != null) {
+										IEditorInput input = ep.getEditorInput();
+										if (input.equals(workunitInput)) {
+											Workbench.getActivePage().activate(ep);
 											((ECLWindow) ep).showItemView((ItemView)next, false);
+										} else if (input instanceof IFileEditorInput) {
+											IFileEditorInput fileInput = (IFileEditorInput)input; 
+											IFile file = fileInput.getFile();
+											String editorPath = file.getFullPath().toPortableString();
+											String workunitPath = workunitInput.getOrigonalFilePath();
+											if (editorPath.compareTo(workunitPath) == 0) {
+												Workbench.getActivePage().activate(ep);
+												((ECLWindow) ep).showItemView((ItemView)next, false);
+											}
 										}
 									}
 								}
+							} else if(Workbench.getActivePerspective().getId().equals(ECLWatch.PERSPECTIVE_ID)) {
+								showWebPage(item, true);
 							}
-
-							//  ECL Watch View  ---
-							showWebPage(item, true);
+							break;
 						}
 					}
 				}
@@ -329,21 +332,24 @@ public class PlatformViewer extends ViewPart {
 					if (selection.size() >= 1) {
 						if (selection.getFirstElement() instanceof ItemView) {
 							ItemView item = (ItemView) selection.getFirstElement();
-							WorkunitView wuView = item.getWorkunitAncestor();
-							if (wuView != null) {
-								WorkunitInput workunitInput = new WorkunitInput(wuView.getWorkunit());
-								try {
-									IEditorPart ep = null;
-									if (workunitInput.origonalFileExists()) {
-										ep = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), workunitInput.getOrigonalFile(), true);
-									} else {
-										ep = IDE.openEditor(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage(), workunitInput, "org.hpccsystems.eclide.editors.ECLWindow");
+
+							if (Workbench.getActivePerspective().getId().equals(ECLPerspective.PERSPECTIVE_ID)) {
+								WorkunitView wuView = item.getWorkunitAncestor();
+								if (wuView != null) {
+									WorkunitInput workunitInput = new WorkunitInput(wuView.getWorkunit());
+									try {
+										IEditorPart ep = null;
+										if (workunitInput.origonalFileExists()) {
+											ep = IDE.openEditor(Workbench.getActivePage(), workunitInput.getOrigonalFile(), true);
+										} else {
+											ep = IDE.openEditor(Workbench.getActivePage(), workunitInput, "org.hpccsystems.eclide.editors.ECLWindow");
+										}
+										if (ep instanceof ECLWindow) {
+											((ECLWindow) ep).showItemView(item, true);
+										}
+									} catch (PartInitException e) {
+										e.printStackTrace();
 									}
-									if (ep instanceof ECLWindow) {
-										((ECLWindow) ep).showItemView(item, true);
-									}
-								} catch (PartInitException e) {
-									e.printStackTrace();
 								}
 							}
 						}

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/wizards/ECLNewFileWizard.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/wizards/ECLNewFileWizard.java
@@ -36,6 +36,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.ide.IDE;
+import org.hpccsystems.eclide.Workbench;
 
 public class ECLNewFileWizard extends Wizard implements INewWizard {
 	private ECLNewFileWizardPage page;
@@ -125,8 +126,7 @@ public class ECLNewFileWizard extends Wizard implements INewWizard {
 		getShell().getDisplay().asyncExec(new Runnable() {
 			@Override
 			public void run() {
-				IWorkbenchPage page =
-						PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+				IWorkbenchPage page = Workbench.getActivePage();
 				try {
 					IDE.openEditor(page, file, true);
 				} catch (PartInitException e) {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/Eclipse.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/Eclipse.java
@@ -27,12 +27,12 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.console.IConsoleManager;
 import org.eclipse.ui.console.MessageConsole;
 import org.eclipse.ui.ide.IDE;
+import org.hpccsystems.eclide.Workbench;
 import org.hpccsystems.eclide.ui.viewer.HtmlViewer;
 import org.hpccsystems.eclide.ui.viewer.platform.WorkunitsViewer;
 
@@ -131,7 +131,7 @@ public class Eclipse {
 	}
 
 	static public void showHtmlViewer() {
-		IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+		IWorkbenchWindow[] windows = Workbench.getWorkbenchWindows();
 		for (int i = 0; i < windows.length; ++i) {
 			final IWorkbenchPage window = windows[i].getActivePage();
 			if (window != null) {
@@ -217,7 +217,7 @@ public class Eclipse {
 	//  Dirty Helpers  ---
 	static protected IResource[] getScopedDirtyResources(IProject[] projects) {
 		HashSet<IResource> dirtyres = new HashSet<IResource>();
-		IWorkbenchWindow[] windows = PlatformUI.getWorkbench().getWorkbenchWindows();
+		IWorkbenchWindow[] windows = Workbench.getWorkbenchWindows();
 		for (int l = 0; l < windows.length; l++) {
 			IWorkbenchPage[] pages = windows[l].getPages();
 			for (int i = 0; i < pages.length; i++) {

--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/Platform.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/Platform.java
@@ -23,8 +23,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 import org.hpccsystems.eclide.Activator;
+import org.hpccsystems.eclide.Workbench;
 import org.hpccsystems.eclide.builder.ECLCompiler;
 import org.hpccsystems.eclide.builder.Version;
 import org.hpccsystems.internal.ConfigurationPreferenceStore;
@@ -148,11 +148,11 @@ public class Platform extends DataSingleton {
 	}
 
 	synchronized void confirmDisable() {
-		PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
+		Workbench.getDisplay().syncExec(new Runnable() {
 			@Override
 			public void run() {
 				if (!isDisabled()) {
-					Shell activeShell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+					Shell activeShell = Workbench.getShell();
 					if (MessageDialog.openConfirm(activeShell, "ECL Plug-in", "\"" + name + "\" is Unreachable.  Disable for current session?\n(Can be permanently disabled in the Launch Configuration)")) {
 						isTempDisabled = true;
 					}


### PR DESCRIPTION
While in ECL Watch Perspective, the WU editor should not be activated.

Fixes EPE-34

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
