### PR TITLE
EPE-98 Update signing certificate (2014)

### DIFF
--- a/sign.bat
+++ b/sign.bat
@@ -1,7 +1,7 @@
-set JARSIGNER=c:\Program Files\Java\jdk1.7.0_25\bin\jarsigner.exe
+set JARSIGNER=c:\Program Files\Java\jdk1.7.0_40\bin\jarsigner.exe
 set KEYSTORE=..\sign\hpcc_code_signing.pfx
 set TSA=https://timestamp.geotrust.com/tsa
-set STOREPASS=%1
+set /p STOREPASS=<..\sign\passphrase.txt
 
 set SIGN_FILTER=.\org.hpccsystems.updatesite\features\*.jar
 CALL :DOSIGN 


### PR DESCRIPTION
Tweak batch file to use passphrase.txt inline with ECL IDE and ClientTools.

Fixes EPE-98

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
