### PR TITLE
EPE-97 ECL Editor should re-use global Text Editor preferences

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLConfiguration.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLConfiguration.java
@@ -12,6 +12,7 @@ package org.hpccsystems.eclide.editors;
 
 import java.util.Arrays;
 
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextHover;
 import org.eclipse.jface.text.TextAttribute;
@@ -77,7 +78,8 @@ public class ECLConfiguration extends TextSourceViewerConfiguration {
 	private ECLScanner scanner;
 	private ECLColorManager colorManager;
 
-	public ECLConfiguration(ECLColorManager colorManager) {
+	public ECLConfiguration(IPreferenceStore preferenceStore, ECLColorManager colorManager) {
+		super(preferenceStore);
 		this.colorManager = colorManager;
 	}
 

--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLEditor.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/editors/ECLEditor.java
@@ -61,7 +61,7 @@ public class ECLEditor extends TextEditor {
 		super();
 		readOnly = false;
 		colorManager = new ECLColorManager();
-		setSourceViewerConfiguration(new ECLConfiguration(colorManager));
+		setSourceViewerConfiguration(new ECLConfiguration(getPreferenceStore(), colorManager));
 		setDocumentProvider(new ECLDocumentProvider());
 		setKeyBindingScopes( new String[] { "org.hpccsystems.eclide.eclideScope" } );
 	}


### PR DESCRIPTION
Fixes EPE-97

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
