### PR TITLE
EPE-116 Plugin fails on system with 1.6JRE

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
@@ -143,12 +143,9 @@ public class ClientTools extends DataSingleton implements Comparable<ClientTools
 		Recent = this;
 		ECLCompiler retVal = null;
 		String ext = file.getFileExtension().toLowerCase();
-		switch(ext) {
-		case "kel":
+		if(ext.compareToIgnoreCase("kel") == 0){
 			retVal = new PluginCompiler(rootPath, ext);
-			break;
-		case "ecl":
-		default:
+		} else {
 			retVal = new ECLCompiler(rootPath);
 		}
 		retVal.setPreferences(preferences);

--- a/org.hpccsystems.feature/feature.xml
+++ b/org.hpccsystems.feature/feature.xml
@@ -152,4 +152,12 @@ This Agreement is governed by the laws of the State of New York and the intellec
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.hpccsystems.eclide.nl"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
switch(STRING) is not supported in 1.6.
Added language fragment to build dependencies.

Fixes EPE-116

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
