### PR TITLE
EPE-128 Plugins fail if file is not in a folder within the project

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/PluginCompiler.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/eclide/builder/PluginCompiler.java
@@ -162,7 +162,7 @@ public class PluginCompiler extends ECLCompiler {
 			errFile.deleteOnExit();
 
 			try {
-				String args = action + " " + modAttrLabel[0] + " " + modAttrLabel[1] + " " + file.getLocation().toOSString() + " " + outFile.getAbsolutePath() + " " + errFile.getAbsolutePath();
+				String args = action + " \"" + modAttrLabel[0] + "\" \"" + modAttrLabel[1] + "\" " + file.getLocation().toOSString() + " " + outFile.getAbsolutePath() + " " + errFile.getAbsolutePath();
 				CmdArgs cmdArgs = new CmdArgs(scriptFile.getPath(), args, "");
 	
 				CmdProcess process = new CmdProcess(scriptFolder, new Path(""), handler, eclccConsoleWriter);


### PR DESCRIPTION
Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
