### PR TITLE
EPE-135 Non Windows OS assumes server is installed

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
@@ -238,7 +238,10 @@ public class ClientTools extends DataSingleton implements Comparable<ClientTools
 			if (hpccSystemsFolder.exists() && hpccSystemsFolder.isDirectory()) {
 				if (!OS.isWindowsPlatform()) {
 					//  Check for server installation  ---
-					retVal.add(new ClientTools(hpccSystemsFolder.toString()));					
+					File clientToolsPath = new Path(hpccSystemsFolder.toString()).append("bin").append("eclcc").toFile(); //$NON-NLS-1$
+					if (clientToolsPath.exists()) {
+						retVal.add(new ClientTools(hpccSystemsFolder.toString()));
+					}
 				}
 				File[] versionFolders = hpccSystemsFolder.listFiles();
 				for (File versionFolder : versionFolders) {


### PR DESCRIPTION
Non windows OS automatically adds /opt/HPCCSystems/bin/eclcc to list of known compilers.

Fixes EPE-135

Signed-off-by: Gordon Smith gordon.smith@lexisnexis.com
