### PR TITLE
EPE-152 Launch Configuration Ignored

### DIFF
--- a/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
+++ b/org.hpccsystems.eclide/src/org/hpccsystems/internal/data/ClientTools.java
@@ -62,7 +62,9 @@ public class ClientTools extends DataSingleton implements Comparable<ClientTools
 		if (ct == null) {
 			return null;
 		}
-		return (ClientTools)All.get(ct);
+		ClientTools retVal = (ClientTools)All.get(ct);
+		retVal.init(preferences);
+		return retVal;
 	}
 
 	public static final String P_KNOWNTOOLSPATH = "knownToolsPathPreference"; //$NON-NLS-1$


### PR DESCRIPTION
Once cached a launch configuration ignored configuration updates.

Fixes EPE-152

Signed-off-by: Gordon Smith <gordonjsmith@gmail.com>